### PR TITLE
🩹 [Patch]: Enabled actions to verify the template is in a deployable state

### DIFF
--- a/.github/PSModule.yml
+++ b/.github/PSModule.yml
@@ -3,7 +3,7 @@
 # - https://github.com/PSModule/Process-PSModule?tab=readme-ov-file#configuration
 
 # The template comes with all the default values, so you can update the ones you want to change, and remove the ones you don't. Including this comment.
-Name: null
+Name: Template-PSModule
 
 Build:
   Skip: false

--- a/.github/PSModule.yml
+++ b/.github/PSModule.yml
@@ -2,66 +2,6 @@
 # Reference:
 # - https://github.com/PSModule/Process-PSModule?tab=readme-ov-file#configuration
 
-# The template comes with all the default values, so you can update the ones you want to change, and remove the ones you don't. Including this comment.
-Name: Template-PSModule
-
-Build:
-  Skip: false
-  Module:
-    Skip: false
-  Docs:
-    Skip: false
-  Site:
-    Skip: false
-
 Test:
-  Skip: false
-  Linux:
-    Skip: false
-  MacOS:
-    Skip: false
-  Windows:
-    Skip: false
-  SourceCode:
-    Skip: false
-    Linux:
-      Skip: false
-    MacOS:
-      Skip: false
-    Windows:
-      Skip: false
-  PSModule:
-    Skip: false
-    Linux:
-      Skip: false
-    MacOS:
-      Skip: false
-    Windows:
-      Skip: false
-  Module:
-    Skip: false
-    Linux:
-      Skip: false
-    MacOS:
-      Skip: false
-    Windows:
-      Skip: false
-  TestResults:
-    Skip: false
   CodeCoverage:
-    Skip: false
     PercentTarget: 0
-    StepSummaryMode: 'Missed, Files'
-
-Publish:
-  Module:
-    Skip: false
-    AutoCleanup: true
-    AutoPatching: true
-    IncrementalPrerelease: true
-    DatePrereleaseFormat: ''
-    VersionPrefix: 'v'
-    MajorLabels: 'major, breaking'
-    MinorLabels: 'minor, feature'
-    PatchLabels: 'patch, fix'
-    IgnoreLabels: 'NoRelease'


### PR DESCRIPTION
## Description

This pull request updates the `.github/PSModule.yml` file to set a meaningful default value for the `Name` field.

* [`.github/PSModule.yml`](diffhunk://#diff-928165ed381f1982eb8f9746a59a2829db4abc8a28eddb8c109e12bb033ff96aL6-R6): Changed the `Name` field from `null` to `Template-PSModule` to provide a clear and descriptive default name.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
